### PR TITLE
[WIP][Do not merge] Better handling of meta chunk

### DIFF
--- a/src/streams/uploadStream.js
+++ b/src/streams/uploadStream.js
@@ -27,7 +27,6 @@ export default class UploadStream extends Writable {
 
     super(opts);
     this.options = opts;
-    this.metachunk = metachunk;
     this.genesisHash = genesisHash;
     this.numChunks = numChunks;
     this.alpha = alpha;
@@ -35,7 +34,7 @@ export default class UploadStream extends Writable {
     this.sessIdA = sessIdA;
     this.sessIdB = sessIdB;
     this.chunkBufferLow = [metachunk];
-    this.chunkBufferHigh = [];
+    this.chunkBufferHigh = [metachunk];
     this.batchBuffer = [];
     this.ongoingUploads = 0;
     this.chunksProcessed = 0;
@@ -77,9 +76,6 @@ export default class UploadStream extends Writable {
 
   _final(callback) {
     this.finishCallback = callback;
-
-    // Appends metachunk to beta.
-    this.chunkBufferHigh.push(this.metachunk);
 
     if (this.chunkBufferLow.length > 0) {
       this.batchBuffer.push({


### PR DESCRIPTION
 Since order of array doesnt matter (brokers use `idx` on chunk object), we can send the meta chunk to beta earlier to make sure it gets there and is saved. This is more reliable and slightly cleans up the code.